### PR TITLE
Use SD card for persistent data rather than EEPROM

### DIFF
--- a/lib/util/persistent.h
+++ b/lib/util/persistent.h
@@ -34,7 +34,7 @@ struct PersistentVals {
 
 PersistentVals newPersistentVals();
 
-struct EEPROMWrapper {
+struct SettingsWrapper {
     byte written; // signal that we wrote the EEPROM, there might be something better
     PersistentVals persistentVals;
     UserSettings userSettings;

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,3 +47,4 @@ lib_deps =
 	Wire
 	SPI
 	adafruit/Ethernet2@^1.0.4
+	SD

--- a/src/solenoid.cpp
+++ b/src/solenoid.cpp
@@ -19,9 +19,7 @@ void updateSolenoids(Solenoids& solenoids, unsigned long time, float pressure, b
         }
     } else if (solenoids.state == Pulsing) {
         int timeAllowed = 150;
-#ifndef DEBUG
         timeAllowed = modbusTCPServer.holdingRegisterRead(PulseOnTime);
-#endif
         if (time - solenoids.lastUpdated > timeAllowed) {
             digitalWrite(SOLENOID_ARRAY[solenoids.currentSolenoid], LOW);
             solenoids.state = Waiting;
@@ -30,9 +28,7 @@ void updateSolenoids(Solenoids& solenoids, unsigned long time, float pressure, b
         }
     } else if (solenoids.state == Waiting) {
         int timeAllowed = 1000;
-#ifndef DEBUG
         timeAllowed = 1000 * modbusTCPServer.holdingRegisterRead(PulseOffTime);
-#endif
         if (time - solenoids.lastUpdated > timeAllowed) {
             if (!override && (pressure <= readModbusFloat(LowLimit))) {
                 solenoids.state = WaitingForHigh;


### PR DESCRIPTION
Replace read/writes of EEPROM data with the equivalent for the SD card.